### PR TITLE
Fixes potential races during LISTEN initiation

### DIFF
--- a/pgpubsub/listen.py
+++ b/pgpubsub/listen.py
@@ -111,9 +111,12 @@ def listen_to_channels(channels: Union[List[BaseChannel], List[str]] = None):
     if not channels:
         raise ChannelNotFound()
     cursor = connection.cursor()
-    for channel in channels:
-        logger.info(f'Listening on {channel.name()}\n')
-        cursor.execute(f'LISTEN {channel.listen_safe_name()};')
+    # Notifications are started to being delivered only after the transaction commits.
+    # Check LISTEN documentation for detailed description.
+    with transaction.atomic():
+        for channel in channels:
+            logger.info(f'Listening on {channel.name()}\n')
+            cursor.execute(f'LISTEN {channel.listen_safe_name()};')
     return ConnectionWrapper(connection.connection)
 
 


### PR DESCRIPTION
While working on a https://github.com/PaulGilmartin/django-pgpubsub/pull/81 I've noticed that the LISTEN initiation does not follow the guidelines from the https://www.postgresql.org/docs/current/sql-listen.html. 

Here's the quote:

> There is a race condition when first setting up a listening session: if concurrently-committing transactions are sending notify events, exactly which of those will the newly listening session receive? The answer is that the session will receive all events committed after an instant during the transaction's commit step. But that is slightly later than any database state that the transaction could have observed in queries. This leads to the following rule for using LISTEN: first execute (and commit!) that command, then in a new transaction inspect the database state as needed by the application logic, then rely on notifications to find out about subsequent changes to the database state. The first few received notifications might refer to updates already observed in the initial database inspection, but this is usually harmless.

So this MR wraps `LISTEN` into a transaction to avoid races namely lost notifications while the listener is starging.